### PR TITLE
Add cover image to the content.opdf output

### DIFF
--- a/src/Generator/EpubGenerator.php
+++ b/src/Generator/EpubGenerator.php
@@ -241,9 +241,16 @@ class EpubGenerator
             $conformsToElement->setAttribute('property', 'dcterms:conformsTo');
             $metadataElement->appendChild($conformsToElement);
         }
+
+        if ($metadata->getCover()) {
+            $coverMeta = $dom->createElement('meta');
+            $coverMeta->setAttribute('name', 'cover');
+            $coverMeta->setAttribute('content', 'cover-image');
+            $metadataElement->appendChild($coverMeta);
+        }
     }
 
-    private function addManifestItems(DOMDocument $dom, \DOMElement $manifest, array $chapters, array $images, array $stylesheets): void
+    private function addManifestItems(DOMDocument $dom, \DOMElement $manifest, Metadata $metadata, array $chapters, array $images, array $stylesheets): void
     {
         // Navegación
         $navItem = $dom->createElement('item');
@@ -252,6 +259,16 @@ class EpubGenerator
         $navItem->setAttribute('media-type', 'application/xhtml+xml');
         $navItem->setAttribute('properties', 'nav');
         $manifest->appendChild($navItem);
+
+        // Cover
+        if ($metadata->getCover()) {
+            $coverItem = $dom->createElement('item');
+            $coverItem->setAttribute('id', 'cover-image');
+            $coverItem->setAttribute('href', 'Images/cover' . $this->getImageExtension($metadata->getCover()));
+            $coverItem->setAttribute('media-type', $this->getImageMimeType($metadata->getCover()));
+            $coverItem->setAttribute('properties', 'cover-image');
+            $manifest->appendChild($coverItem);
+        }
 
         // CSS por defecto
         $cssItem = $dom->createElement('item');

--- a/src/Generator/EpubGenerator.php
+++ b/src/Generator/EpubGenerator.php
@@ -107,7 +107,7 @@ class EpubGenerator
         $manifest = $dom->createElement('manifest');
         $package->appendChild($manifest);
 
-        $this->addManifestItems($dom, $manifest, $chapters, $images, $stylesheets);
+        $this->addManifestItems($dom, $manifest, $metadata, $chapters, $images, $stylesheets);
 
         // Spine
         $spine = $dom->createElement('spine');


### PR DESCRIPTION
This PR ensures that when a cover image is set, it is declared in the EPUB (`OEBPS/content.opf`).